### PR TITLE
Feat/viz tool  diagnosis enum

### DIFF
--- a/bokeh-demo/bokeh_demo/backend.py
+++ b/bokeh-demo/bokeh_demo/backend.py
@@ -20,7 +20,7 @@ from bokeh.models import (
     UnionFilter,
 )
 
-from .exam_data import EXAM_RESULT_LOOKUP, ExamResult
+from .exam_data import ExamResult
 from .faker import faker
 from .settings import settings
 
@@ -212,9 +212,7 @@ class Person:
                 exam.type.value for exam in self.detailed_exam_results if exam
             ],
             "exam_result": [
-                EXAM_RESULT_LOOKUP[exam.type][exam.result]
-                for exam in self.detailed_exam_results
-                if exam
+                exam.result.value for exam in self.detailed_exam_results if exam
             ],
         }
 

--- a/bokeh-demo/bokeh_demo/exam_data.py
+++ b/bokeh-demo/bokeh_demo/exam_data.py
@@ -8,47 +8,54 @@ class ExamTypes(str, Enum):
     HPV = "HPV"
 
 
+class Diagnosis(str, Enum):
+    CytDiagnosis0 = "CytDiagnosis0"
+    CytDiagnosis1 = "CytDiagnosis1"
+    CytDiagnosis2 = "CytDiagnosis2"
+    HistDiagnosis0 = "HistDiagnosis0"
+    HistDiagnosis1 = "HistDiagnosis1"
+    HistDiagnosis2 = "HistDiagnosis2"
+    HistDiagnosis3 = "HistDiagnosis3"
+    HistDiagnosis4 = "HistDiagnosis4"
+    HPVNegative = "HPV Negative"
+    HPVPositive = "HPV Positive"
+
+
 @dataclass
 class ExamResult:
     type: ExamTypes
-    result: int  # Must be looked up
+    result: Diagnosis
 
 
 EXAM_RESULT_LOOKUP = {
     ExamTypes.Cytology: [
-        "CytDiagnosis0",
-        "CytDiagnosis1",
-        "CytDiagnosis2",
+        Diagnosis.CytDiagnosis0,
+        Diagnosis.CytDiagnosis1,
+        Diagnosis.CytDiagnosis2,
     ],
     ExamTypes.Histology: [
-        "HistDiagnosis0",
-        "HistDiagnosis1",
-        "HistDiagnosis2",
-        "HistDiagnosis3",
-        "HistDiagnosis4",
+        Diagnosis.HistDiagnosis0,
+        Diagnosis.HistDiagnosis1,
+        Diagnosis.HistDiagnosis2,
+        Diagnosis.HistDiagnosis3,
+        Diagnosis.HistDiagnosis4,
     ],
     ExamTypes.HPV: [
-        "HPV Negative",
-        "HPV Positive",
+        Diagnosis.HPVNegative,
+        Diagnosis.HPVPositive,
     ],
 }
 
 # Mapping from diagnosis to coarse state
 EXAM_RESULT_MAPPING = {
-    ExamTypes.Cytology: [
-        1,
-        2,
-        3,
-    ],
-    ExamTypes.Histology: [
-        1,
-        1,
-        2,
-        3,
-        4,
-    ],
-    ExamTypes.HPV: [
-        1,
-        3,
-    ],
+    Diagnosis.CytDiagnosis0: 1,
+    Diagnosis.CytDiagnosis1: 2,
+    Diagnosis.CytDiagnosis2: 3,
+    Diagnosis.HistDiagnosis0: 1,
+    Diagnosis.HistDiagnosis1: 1,
+    Diagnosis.HistDiagnosis2: 2,
+    Diagnosis.HistDiagnosis3: 3,
+    Diagnosis.HistDiagnosis4: 4,
+    Diagnosis.HPVNegative: 1,
+    Diagnosis.HPVPositive: 3,
 }

--- a/bokeh-demo/tests/test_backend.py
+++ b/bokeh-demo/tests/test_backend.py
@@ -15,7 +15,7 @@ from bokeh_demo.backend import (
     parse_filter_to_indices,
 )
 from bokeh_demo.exam_data import ExamTypes
-from bokeh_demo.faker import get_inverse_mapping
+from bokeh_demo.faker import coarse_to_exam_result
 
 
 @st.composite
@@ -60,7 +60,7 @@ def test_combine_scatter_dicts(dictionaries: list[dict]) -> None:
         assert value == flattened
 
 
-COARSE_TO_RESULT_MAPPING = get_inverse_mapping()
+COARSE_TO_RESULT_MAPPING = coarse_to_exam_result()
 
 
 def exam_result_strategy(coarse_result: int | None = None):


### PR DESCRIPTION
Changing the diagnosis from `int` to an `Diagnosis` enum allows for much more flexibility in the future, and more type security.

We will also in the future (and for the demo) add several test types that may share part or all of their diagnosis domain etc., and with this solution the data setup is much less error prone and more readable.