### PR TITLE
Fix indexing issue for pilot filters

### DIFF
--- a/bokeh-demo/bokeh_demo/backend.py
+++ b/bokeh-demo/bokeh_demo/backend.py
@@ -234,7 +234,7 @@ class BaseFilter:
 
         exam_to_person_mapping : a sequence with the person index of each exam, i.e.
             element number n contains the index of the person belonging to exam n.
-            Typically, this is retrieved from a source as `exam_source.data["PID"]`
+            Typically, this is retrieved from a source as `exam_source.data["person_index"]`
         """
         return [
             i
@@ -250,7 +250,7 @@ class BaseFilter:
 
         exam_to_person_mapping : a sequence with the person index of each exam, i.e.
             element number n contains the index of the person belonging to exam n.
-            Typically, this is retrieved from a source as `exam_source.data["PID"]`
+            Typically, this is retrieved from a source as `exam_source.data["person_index"]`
         """
         return list({exam_to_person_mapping[i] for i in exam_indices})
 
@@ -295,7 +295,9 @@ class PersonSimpleFilter(SimpleFilter):
         active: bool = False,
         inverted: bool = False,
     ) -> None:
-        exam_to_person = cast(Sequence[int], source_manager.exam_source.data["PID"])
+        exam_to_person = cast(
+            Sequence[int], source_manager.exam_source.data["person_index"]
+        )
         exam_indices = self._person_to_exam_indices(person_indices, exam_to_person)
         super().__init__(
             person_indices,
@@ -316,7 +318,9 @@ class ExamSimpleFilter(SimpleFilter):
         active: bool = False,
         inverted: bool = False,
     ) -> None:
-        exam_to_person = cast(Sequence[int], source_manager.exam_source.data["PID"])
+        exam_to_person = cast(
+            Sequence[int], source_manager.exam_source.data["person_index"]
+        )
         person_indices = self._exam_to_person_indices(exam_indices, exam_to_person)
         super().__init__(
             person_indices,
@@ -348,7 +352,7 @@ class RangeFilter(BaseFilter):
         self.field = field
         self.selected = self._get_selection_indices()
         self.exams_selected = self._person_to_exam_indices(
-            self.selected, self.source_manager.exam_source.data["PID"]
+            self.selected, self.source_manager.exam_source.data["person_index"]
         )
 
     def _get_selection_indices(self) -> list[int]:
@@ -370,7 +374,7 @@ class RangeFilter(BaseFilter):
             self._range = new
             self.selected = self._get_selection_indices()
             self.exams_selected = self._person_to_exam_indices(
-                self.selected, self.source_manager.exam_source.data["PID"]
+                self.selected, self.source_manager.exam_source.data["person_index"]
             )
             self.source_manager.update_views()
 
@@ -434,7 +438,7 @@ class CategoricalFilter(BaseFilter):
 
         self.selected = self._get_selection_indices()
         self.exams_selected = self._person_to_exam_indices(
-            self.selected, self.source_manager.exam_source.data["PID"]
+            self.selected, self.source_manager.exam_source.data["person_index"]
         )
 
     def _get_selection_indices(self) -> list[int]:
@@ -451,7 +455,7 @@ class CategoricalFilter(BaseFilter):
             self._categories = new
             self.selected = self._get_selection_indices()
             self.exams_selected = self._person_to_exam_indices(
-                self.selected, self.source_manager.exam_source.data["PID"]
+                self.selected, self.source_manager.exam_source.data["person_index"]
             )
             self.source_manager.update_views()
 

--- a/bokeh-demo/examples/pilot/main.py
+++ b/bokeh-demo/examples/pilot/main.py
@@ -98,12 +98,16 @@ def example_app(source_manager):
         curdoc().add_root(element)
 
 
+HIGH_RISK_STATES = {3, 4}
+"""Risk levels that are considered high risk."""
+
+
 def _at_least_one_high_risk(person_source):
     """Return people with at least one high risk"""
     return [
         i
         for i, exam_results in enumerate(person_source.data["exam_results"])
-        if 3 in exam_results
+        if not set(exam_results).isdisjoint(HIGH_RISK_STATES)
     ]
 
 
@@ -118,7 +122,7 @@ def _get_filters(source_manager: SourceManager) -> dict[str, BaseFilter]:
             exam_indices=[
                 i
                 for i, state in enumerate(source_manager.exam_source.data["risk"])
-                if state == 3
+                if state in HIGH_RISK_STATES
             ],
         ),
     }
@@ -177,6 +181,11 @@ def main():
     # Warning!
     # This is not the same DataFrame as `DataManager.person_df`.
     person_df = CreatePersonSource().fit_transform(exams_df)
+
+    # Add column in exams_df referring to the index of a person in person_df, _not_
+    # the PID. This is for simpler lookups later
+    pid_to_index = {pid: i for i, pid in enumerate(person_df["PID"])}
+    exams_df["person_index"] = exams_df["PID"].map(pid_to_index)
 
     source_manager = SourceManager(
         ColumnDataSource(person_df),


### PR DESCRIPTION
Due to the recent switch from index to PID, the filters used the index wrongly. Here we add a new column, person_index, whicih is just the person's sequential index, making the filters work as before.