### PR TITLE
Can 268/detailed info

### DIFF
--- a/bokeh-demo/bokeh_demo/data_ingestion.py
+++ b/bokeh-demo/bokeh_demo/data_ingestion.py
@@ -128,37 +128,10 @@ exams_pipeline = Pipeline(
 )
 
 
-def _hpv_details_per_exam(hpv_df: pd.DataFrame) -> pd.DataFrame:
-    """Return a DataFrame with the HPV details per exam.
-
-    The index of the returned DataFrame is the exam_index. Note that this is
-    not the same as the index of the exams_df!"""
-
-    per_exam = hpv_df.groupby("exam_index")
-    if per_exam["hpvTesttype"].nunique().max() != 1:
-        raise ValueError("Not all exams have the same HPV test type!")
-
-    return pd.DataFrame(
-        {
-            "exam_detailed_type": per_exam["test_type_name"].first(),
-            "exam_detailed_results": per_exam["genotype"].apply(
-                lambda genotypes: ",".join(genotypes)
-            ),
-        }
-    )
-
-
 def add_hpv_detailed_information(
     exams_df: pd.DataFrame, hpv_df: pd.DataFrame
 ) -> pd.DataFrame:
-    """ "Add detailed exam type name and results to exams_df
-
-    Adds two columns to exams_df:
-    - exam_detailed_type: the detailed exam type name
-    - exam_detailed_results: the detailed exam results
-    """
-    # TODO: Will this give a bug when there is no genotype information for an exam?
-    # Then, there is no rows, so we have no exam type info
+    """Add detailed results to exams_df, under the key "exam_detailed_results"."""
 
     # Find the exam_index -> exams_df.index map
     # exam_index is not unique in exams_df, because one exam may give
@@ -167,19 +140,16 @@ def add_hpv_detailed_information(
     hpv_indices = exams_df.query("exam_type == 'HPV'")["index"]
     mapping = pd.Series(data=hpv_indices.index, index=hpv_indices.values)
 
-    hpv_details = _hpv_details_per_exam(hpv_df)
+    hpv_details = hpv_df.groupby("exam_index")["genotype"].apply(",".join)
     hpv_details.index = hpv_details.index.map(mapping)
 
-    exams_df = exams_df.join(hpv_details)
+    exams_df["exam_detailed_results"] = hpv_details
 
     # Set the Cytology and Histology results
     def _fill(base_series: pd.Series, fill_series: pd.Series) -> pd.Series:
         """Fill base series with fill series where base series is nan. Handles category data."""
         return base_series.astype("string").fillna(fill_series.astype("string"))
 
-    exams_df["exam_detailed_type"] = _fill(
-        exams_df["exam_detailed_type"], exams_df["exam_type"]
-    )
     exams_df["exam_detailed_results"] = _fill(
         exams_df["exam_detailed_results"], exams_df["exam_diagnosis"]
     )

--- a/bokeh-demo/bokeh_demo/frontend.py
+++ b/bokeh-demo/bokeh_demo/frontend.py
@@ -189,7 +189,7 @@ class LexisPlot(ToolsMixin):
         # Tooltip for detailed exam data
         hover_tool = HoverTool(
             tooltips=[
-                ("Type", "@exam_detailed_type"),
+                ("Type", "@detailed_exam_type"),
                 ("Result", "@exam_detailed_results"),
             ],
             renderers=[self.scatter],

--- a/bokeh-demo/bokeh_demo/frontend.py
+++ b/bokeh-demo/bokeh_demo/frontend.py
@@ -188,7 +188,10 @@ class LexisPlot(ToolsMixin):
 
         # Tooltip for detailed exam data
         hover_tool = HoverTool(
-            tooltips=[("Type", "@exam_type"), ("Result", "@exam_diagnosis")],
+            tooltips=[
+                ("Type", "@exam_detailed_type"),
+                ("Result", "@exam_detailed_results"),
+            ],
             renderers=[self.scatter],
         )
         self.figure.add_tools(hover_tool)

--- a/bokeh-demo/examples/pilot/main.py
+++ b/bokeh-demo/examples/pilot/main.py
@@ -23,7 +23,11 @@ from bokeh_demo.backend import (
     PersonSimpleFilter,
     SourceManager,
 )
-from bokeh_demo.data_ingestion import CreatePersonSource, exams_pipeline
+from bokeh_demo.data_ingestion import (
+    CreatePersonSource,
+    add_hpv_detailed_information,
+    exams_pipeline,
+)
 from bokeh_demo.frontend import (
     HistogramPlot,
     LexisPlot,
@@ -172,7 +176,8 @@ def main():
         data_manager = DataManager.read_from_csv(
             settings.data_paths.screening_data_path, settings.data_paths.dob_data_path
         )
-    exams_df = data_manager.exams_df
+    # Add detailed test type and results information to exams_df
+    exams_df = add_hpv_detailed_information(data_manager.exams_df, data_manager.hpv_df)
 
     exams_df = extract_people_from_pids([], exams_df)
     exams_df = exams_df.drop(columns=["index"]).reset_index(drop=True)

--- a/bokeh-demo/poetry.lock
+++ b/bokeh-demo/poetry.lock
@@ -165,7 +165,7 @@ test-no-images = ["pytest", "pytest-cov", "wurlitzer"]
 
 [[package]]
 name = "decipher"
-version = "0.1.34"
+version = "0.1.35"
 description = "Utilities for Decipher"
 category = "main"
 optional = false
@@ -189,8 +189,8 @@ pyarrow = ["pyarrow (>=11.0.0,<12.0.0)"]
 [package.source]
 type = "git"
 url = "https://github.com/Simula-Consulting/decipher_data_handler"
-reference = "0.1.34"
-resolved_reference = "d48cdda87ea3af31a2470556386c8da4725913ab"
+reference = "0.1.35"
+resolved_reference = "b99ed48286e233265d4eebca0da181c9720290f3"
 
 [[package]]
 name = "exceptiongroup"
@@ -1100,4 +1100,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<3.11"
-content-hash = "565713db63b570442a7063a4dbb6cf62756aa83774edc98228c5888842c1a5d6"
+content-hash = "ae394fec46a553ef25cd97513fa26d63dbda64b81db764dd46ee6f215fd10dc5"

--- a/bokeh-demo/pyproject.toml
+++ b/bokeh-demo/pyproject.toml
@@ -10,7 +10,7 @@ packages = [{include = "bokeh_demo"}]
 python = ">=3.10,<3.11"
 bokeh = "^3.0.2"
 pydantic = "^1.10.2"
-decipher = {git = "https://github.com/Simula-Consulting/decipher_data_handler", extras=["pyarrow"], tag="0.1.34"}
+decipher = {git = "https://github.com/Simula-Consulting/decipher_data_handler", extras=["pyarrow"], tag="0.1.35"}
 
 [tool.poetry.group.dev.dependencies]
 mypy = "^0.982"


### PR DESCRIPTION
Load detailed HPV information, and display it in the tooltip.

The newest version of `DataManager` has `detailed_exam_type` in the exams_df. For cyt and hist, this is the same as `exam_type`, but for HPV it gives the specific HPV test type.
We also add a field `exam_detailed_results` to the exams_df manually, using the hpv df from `DataManager`.